### PR TITLE
Low-risk cleanups

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,6 @@
  (depends
   (ocaml (>= 5.4.1))
   (dune (>= 3.0))
-  base
   core
   (eio (>= 1.0))
   (eio_main (>= 1.0))

--- a/nsq.opam
+++ b/nsq.opam
@@ -10,7 +10,6 @@ bug-reports: "https://github.com/ryanslade/nsq-ocaml/issues"
 depends: [
   "ocaml" {>= "5.4.1"}
   "dune" {>= "3.0"}
-  "base"
   "core"
   "eio" {>= "1.0"}
   "eio_main" {>= "1.0"}

--- a/src/dune
+++ b/src/dune
@@ -5,5 +5,5 @@
   (flags (-show-counts)))
  (preprocess
   (pps ppx_deriving_yojson ppx_jane))
- (libraries base core eio eio.unix cohttp cohttp-eio yojson
+ (libraries core eio eio.unix cohttp cohttp-eio yojson
    ppx_deriving_yojson.runtime hex logs))

--- a/src/nsq.ml
+++ b/src/nsq.ml
@@ -129,10 +129,7 @@ type command =
   | RDY of int
   | NOP
 
-let try_with_string f =
-  match Result.try_with f with
-  | Ok _ as x -> x
-  | Error e -> Error (Exn.to_string e)
+let try_with_string f = Result.try_with f |> Result.map_error ~f:Exn.to_string
 
 module ServerMessage = struct
   type t =
@@ -353,7 +350,7 @@ let query_nsqlookupd ~http_client ~sw ~topic a =
     match Http.Response.status resp with
     | `OK ->
         let body_str =
-          Eio.Buf_read.(parse_exn take_all) body ~max_size:Int.max_value
+          Eio.Buf_read.(parse_exn take_all) body ~max_size:(1 * 1024 * 1024)
         in
         log_and_return "Error parsing lookup response"
           (Lookup.response_of_string body_str)


### PR DESCRIPTION
Three small, independent cleanups; no behaviour changes.

- Simplify `try_with_string` to `Result.try_with f |> Result.map_error ~f:Exn.to_string`.
- Cap the lookupd HTTP response read at 1 MiB instead of `Int.max_value` (which defeated the purpose of `max_size`).
- Drop the explicit `base` dependency from `dune-project` (and the regenerated `nsq.opam`); it's already pulled in transitively via `core`.

Verified with `dune build` (clean) and `dune runtest` (17 tests pass).