### PR TITLE
Remove redundant Stdlib prefixes

### DIFF
--- a/bench/publish_throughput.ml
+++ b/bench/publish_throughput.ml
@@ -27,19 +27,17 @@ let parse_args () =
   let pool_size = ref 1 in
   let specs =
     [
-      ("-host", Stdlib.Arg.Set_string host, " nsqd host (default: localhost)");
-      ("-n", Stdlib.Arg.Set_int count, " total messages to publish");
-      ("-size", Stdlib.Arg.Set_int payload_size, " payload bytes per message");
+      ("-host", Arg.Set_string host, " nsqd host (default: localhost)");
+      ("-n", Arg.Set_int count, " total messages to publish");
+      ("-size", Arg.Set_int payload_size, " payload bytes per message");
       ( "-batch",
-        Stdlib.Arg.Set_int batch_size,
+        Arg.Set_int batch_size,
         " messages per call (1 = PUB, >1 = MPUB)" );
-      ("-topic", Stdlib.Arg.Set_string topic, " topic name");
-      ("-pool", Stdlib.Arg.Set_int pool_size, " producer pool size");
+      ("-topic", Arg.Set_string topic, " topic name");
+      ("-pool", Arg.Set_int pool_size, " producer pool size");
     ]
   in
-  Stdlib.Arg.parse (Stdlib.Arg.align specs)
-    (fun _ -> ())
-    "publish_throughput [options]";
+  Arg.parse (Arg.align specs) (fun _ -> ()) "publish_throughput [options]";
   {
     host = !host;
     count = !count;
@@ -85,9 +83,9 @@ let run args =
   (* Warm-up: one publish to populate the connection. Not counted. *)
   publish_one ();
 
-  Stdlib.Gc.compact ();
-  let gc0 = Stdlib.Gc.quick_stat () in
-  let alloc0 = Stdlib.Gc.allocated_bytes () in
+  Gc.compact ();
+  let gc0 = Gc.quick_stat () in
+  let alloc0 = Gc.allocated_bytes () in
   let cpu0 = Unix.times () in
   let t0 = Eio.Time.now clock in
   for _ = 1 to batches do
@@ -95,8 +93,8 @@ let run args =
   done;
   let t1 = Eio.Time.now clock in
   let cpu1 = Unix.times () in
-  let alloc1 = Stdlib.Gc.allocated_bytes () in
-  let gc1 = Stdlib.Gc.quick_stat () in
+  let alloc1 = Gc.allocated_bytes () in
+  let gc1 = Gc.quick_stat () in
 
   let wall = t1 -. t0 in
   let user = cpu1.tms_utime -. cpu0.tms_utime in
@@ -112,35 +110,33 @@ let run args =
   let allocated = alloc1 -. alloc0 in
   let per_msg f = f /. Float.of_int total_msgs in
 
-  Stdlib.print_endline "publish_throughput";
-  Stdlib.Printf.printf "  host:            %s\n" args.host;
-  Stdlib.Printf.printf "  topic:           %s\n" args.topic;
-  Stdlib.Printf.printf "  total messages:  %d\n" total_msgs;
-  Stdlib.Printf.printf "  batch size:      %d (%d calls)\n" args.batch_size
-    batches;
-  Stdlib.Printf.printf "  payload size:    %d B\n" args.payload_size;
-  Stdlib.Printf.printf "  pool size:       %d\n" args.pool_size;
-  Stdlib.print_endline "";
-  Stdlib.Printf.printf "  wall time:       %.3f s\n" wall;
-  Stdlib.Printf.printf "  user CPU:        %.3f s\n" user;
-  Stdlib.Printf.printf "  sys CPU:         %.3f s\n" sys;
-  Stdlib.Printf.printf "  CPU usage:       %.1f %%\n" cpu_pct;
-  Stdlib.Printf.printf "  throughput:      %.0f msgs/s   %s/s\n" msgs_per_sec
+  print_endline "publish_throughput";
+  Printf.printf "  host:            %s\n" args.host;
+  Printf.printf "  topic:           %s\n" args.topic;
+  Printf.printf "  total messages:  %d\n" total_msgs;
+  Printf.printf "  batch size:      %d (%d calls)\n" args.batch_size batches;
+  Printf.printf "  payload size:    %d B\n" args.payload_size;
+  Printf.printf "  pool size:       %d\n" args.pool_size;
+  print_endline "";
+  Printf.printf "  wall time:       %.3f s\n" wall;
+  Printf.printf "  user CPU:        %.3f s\n" user;
+  Printf.printf "  sys CPU:         %.3f s\n" sys;
+  Printf.printf "  CPU usage:       %.1f %%\n" cpu_pct;
+  Printf.printf "  throughput:      %.0f msgs/s   %s/s\n" msgs_per_sec
     (pp_bytes bytes_per_sec);
-  Stdlib.print_endline "";
-  Stdlib.Printf.printf "  allocated:       %s total, %.1f B/msg\n"
-    (pp_bytes allocated) (per_msg allocated);
-  Stdlib.Printf.printf "  minor words:     %.3e total, %.1f /msg\n" minor
+  print_endline "";
+  Printf.printf "  allocated:       %s total, %.1f B/msg\n" (pp_bytes allocated)
+    (per_msg allocated);
+  Printf.printf "  minor words:     %.3e total, %.1f /msg\n" minor
     (per_msg minor);
-  Stdlib.Printf.printf "  promoted words:  %.3e total, %.1f /msg\n" promoted
+  Printf.printf "  promoted words:  %.3e total, %.1f /msg\n" promoted
     (per_msg promoted);
-  Stdlib.Printf.printf "  major words:     %.3e total, %.1f /msg\n" major
+  Printf.printf "  major words:     %.3e total, %.1f /msg\n" major
     (per_msg major);
-  Stdlib.Printf.printf "  minor GCs:       %d\n"
+  Printf.printf "  minor GCs:       %d\n"
     (gc1.minor_collections - gc0.minor_collections);
-  Stdlib.Printf.printf "  major GCs:       %d\n"
+  Printf.printf "  major GCs:       %d\n"
     (gc1.major_collections - gc0.major_collections);
-  Stdlib.Printf.printf "  compactions:     %d\n"
-    (gc1.compactions - gc0.compactions)
+  Printf.printf "  compactions:     %d\n" (gc1.compactions - gc0.compactions)
 
 let () = run (parse_args ())

--- a/examples/consume.ml
+++ b/examples/consume.ml
@@ -1,4 +1,3 @@
-open Base
 open Eio.Std
 open Nsq
 
@@ -16,7 +15,7 @@ let rate_logger ~clock () =
     let elapsed = Eio.Time.now clock -. !start in
     let per_sec = Float.of_int consumed /. elapsed in
     Logs.debug (fun l -> l "Consumed %d, %f/s" consumed per_sec);
-    if consumed >= expected then Stdlib.exit 0 else loop ()
+    if consumed >= expected then exit 0 else loop ()
   in
   loop ()
 
@@ -26,7 +25,7 @@ let setup_logging level =
   Logs.set_reporter (Logs_fmt.reporter ())
 
 let handler _ =
-  Int.incr consumed;
+  incr consumed;
   `Ok
 
 let () =
@@ -35,7 +34,7 @@ let () =
   let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
   let config =
-    Consumer.Config.create ~max_in_flight:in_flight () |> Result.ok_or_failwith
+    Consumer.Config.create ~max_in_flight:in_flight () |> Result.get_ok
   in
   let consumer =
     Consumer.create ~net ~clock ~mode:`Nsqd ~config [ Host nsqd_address ]

--- a/examples/example.ml
+++ b/examples/example.ml
@@ -1,4 +1,3 @@
-open Base
 open Eio.Std
 open Nsq
 
@@ -14,16 +13,16 @@ let publish_interval_seconds = 1.0
 
 let test_publish ~sw ~net ~clock () =
   let p =
-    Result.ok_or_failwith @@ Producer.create ~sw ~net ~clock (Host nsqd_address)
+    Result.get_ok @@ Producer.create ~sw ~net ~clock (Host nsqd_address)
   in
   let rec loop () =
-    let msg = Eio.Time.now clock |> Float.to_string |> Bytes.of_string in
+    let msg = Eio.Time.now clock |> string_of_float |> Bytes.of_string in
     Logs.debug (fun l -> l "Publishing: %s" (Bytes.to_string msg));
     match Producer.publish p (Topic "Test") msg with
-    | Result.Ok _ ->
+    | Ok _ ->
         Eio.Time.sleep clock publish_interval_seconds;
         loop ()
-    | Result.Error e ->
+    | Error e ->
         Logs.err (fun l -> l "%s" e);
         Eio.Time.sleep clock publish_error_backoff;
         loop ()
@@ -34,7 +33,7 @@ let create_consumer ~net ~clock ~mode chan_name handler =
   let config =
     Consumer.Config.create ~max_in_flight:100
       ~lookupd_poll_interval:(Seconds.of_float 60.0) ()
-    |> Result.ok_or_failwith
+    |> Result.get_ok
   in
   let host_port =
     match mode with

--- a/examples/produce.ml
+++ b/examples/produce.ml
@@ -1,4 +1,3 @@
-open Base
 open Eio.Std
 open Nsq
 
@@ -13,16 +12,16 @@ let batch_size = 20
 
 let publish ~clock p =
   let rec loop () =
-    let msg = Int.to_string !published in
+    let msg = string_of_int !published in
     let messages =
-      List.init batch_size ~f:(fun i ->
-          msg ^ ":" ^ Int.to_string i |> Bytes.of_string)
+      List.init batch_size (fun i ->
+          msg ^ ":" ^ string_of_int i |> Bytes.of_string)
     in
     match Producer.publish_multi p (Topic "Test") messages with
-    | Result.Ok _ ->
+    | Ok _ ->
         published := !published + batch_size;
-        if !published >= to_publish then Stdlib.exit 0 else loop ()
-    | Result.Error e ->
+        if !published >= to_publish then exit 0 else loop ()
+    | Error e ->
         Logs.err (fun l -> l "%s" e);
         Eio.Time.sleep clock publish_error_backoff;
         loop ()
@@ -52,11 +51,10 @@ let () =
   let clock = Eio.Stdenv.clock env in
   Switch.run @@ fun sw ->
   let p =
-    Result.ok_or_failwith
+    Result.get_ok
     @@ Producer.create ~sw ~net ~clock ~pool_size:concurrency
          (Host nsqd_address)
   in
   start := Eio.Time.now clock;
   Fiber.all
-    (rate_logger ~clock
-    :: List.init concurrency ~f:(fun _ () -> publish ~clock p))
+    (rate_logger ~clock :: List.init concurrency (fun _ () -> publish ~clock p))

--- a/src/nsq.ml
+++ b/src/nsq.ml
@@ -96,7 +96,7 @@ module Address = struct
 
   let host s = Host s
   let host_port a p = HostPort (a, p)
-  let compare = Stdlib.compare
+  let compare = compare
   let equal = ( = )
   let hash = Hashtbl.hash
 


### PR DESCRIPTION
This PR completes the modernisation task to remove redundant `Stdlib.` prefixes from the codebase now that Base is gone:
- Replace `Stdlib.compare` with `compare` in the `Address` module (`src/nsq.ml`).
- Remove `Stdlib.` prefixes from `Arg`, `Gc`, `Printf`, and `print_endline` in the throughput benchmark (`bench/publish_throughput.ml`).
- Ensure all other `Bytes` and `String` helpers in `src/nsq.ml` (`String.get_int64_be`, `Bytes.set_int64_be`, etc.) are cleanly referenced directly.