### PR TITLE
Replace ppx_deriving_yojson with ppx_yojson_conv

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,7 @@
   cohttp
   cohttp-eio
   yojson
-  ppx_deriving_yojson
+  ppx_yojson_conv
   ppx_expect
   logs
   fmt

--- a/nsq.opam
+++ b/nsq.opam
@@ -15,7 +15,7 @@ depends: [
   "cohttp"
   "cohttp-eio"
   "yojson"
-  "ppx_deriving_yojson"
+  "ppx_yojson_conv"
   "ppx_expect"
   "logs"
   "fmt"

--- a/src/dune
+++ b/src/dune
@@ -4,13 +4,13 @@
  (inline_tests
   (flags (-show-counts)))
  (preprocess
-  (pps ppx_deriving_yojson ppx_expect))
+  (pps ppx_yojson_conv ppx_expect))
  (libraries
   eio
   eio.unix
   cohttp
   cohttp-eio
   yojson
-  ppx_deriving_yojson.runtime
+  ppx_yojson_conv_lib
   hex
   logs))

--- a/src/nsq.ml
+++ b/src/nsq.ml
@@ -1,4 +1,5 @@
 open Eio.Std
+open! Ppx_yojson_conv_lib.Yojson_conv.Primitives
 
 let try_with_string f =
   match f () with v -> Ok v | exception e -> Error (Printexc.to_string e)
@@ -126,7 +127,7 @@ module IdentifyConfig = struct
     output_buffer_timeout : Milliseconds.t;
     sample_rate : int;
   }
-  [@@deriving yojson { strict = false }]
+  [@@deriving yojson] [@@yojson.allow_extra_fields]
 end
 
 type command =
@@ -294,15 +295,13 @@ module Lookup = struct
     http_port : int;
     version : string;
   }
-  [@@deriving yojson { strict = false }]
+  [@@deriving yojson] [@@yojson.allow_extra_fields]
 
   type response = { channels : string list; producers : producer list }
-  [@@deriving yojson { strict = false }]
+  [@@deriving yojson] [@@yojson.allow_extra_fields]
 
   let response_of_string s =
-    Result.bind
-      (try_with_string (fun () -> Yojson.Safe.from_string s))
-      response_of_yojson
+    try_with_string (fun () -> Yojson.Safe.from_string s |> response_of_yojson)
 
   let producer_addresses lr =
     List.map
@@ -457,7 +456,7 @@ let%expect_test "string_of_mpub" =
    [ 4-byte size in bytes ][ N-byte JSON data ]
 *)
 let string_of_identify c =
-  let data = IdentifyConfig.to_yojson c |> Yojson.Safe.to_string in
+  let data = IdentifyConfig.yojson_of_t c |> Yojson.Safe.to_string in
   let length = String.length data in
   let buf = Buffer.create (9 + 4 + length) in
   Buffer.add_string buf "IDENTIFY\n";


### PR DESCRIPTION
Switch the JSON deriving ppx to jane-street's `ppx_yojson_conv`, which is lighter and actively maintained alongside the rest of the Jane Street toolchain we already depend on.

## Changes
- **dune-project / nsq.opam**: dependency swapped from `ppx_deriving_yojson` to `ppx_yojson_conv`.
- **src/dune**: `(pps ...)` and runtime library updated to `ppx_yojson_conv` + `ppx_yojson_conv_lib`.
- **src/nsq.ml**:
  - `open! Ppx_yojson_conv_lib.Yojson_conv.Primitives` to bring in converters for base types (`float_of_yojson`, etc).
  - `[@@deriving yojson { strict = false }]` → `[@@deriving yojson] [@@yojson.allow_extra_fields]`.
  - `IdentifyConfig.to_yojson` → `IdentifyConfig.yojson_of_t` (ppx_yojson_conv naming convention).
  - `response_of_yojson` now raises on parse error rather than returning a `result`, so `Lookup.response_of_string` wraps the whole parse+convert in `try_with_string`.

## Verification
- `dune build` succeeds.
- `dune runtest src/` (inline expect tests) passes.